### PR TITLE
Implement stubs for function name and insignificantly redesign stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Features implemented partially or completely:
 - Code completion
 - Rename
 - File templates
+- Index Frege files
 
 Features desired:
 - Structure view

--- a/src/main/java/com/plugin/frege/Frege.bnf
+++ b/src/main/java/com/plugin/frege/Frege.bnf
@@ -10,7 +10,7 @@
 
     elementTypeHolderClass="com.plugin.frege.psi.FregeTypes"
     elementTypeClass="com.plugin.frege.psi.FregeElementType"
-    elementTypeFactory("dataNameNative")="com.plugin.frege.psi.FregeElementTypeFactory.factory"
+    elementTypeFactory("dataNameNative|packageClassName")="com.plugin.frege.psi.FregeElementTypeFactory.factory"
     tokenTypeClass="com.plugin.frege.psi.FregeTokenType"
 }
 
@@ -210,6 +210,7 @@ private packageVarid ::= qualifier? qualifier? (weakVarid | DATA | IMPORT | NATI
 packageClassName ::= qConId {
     implements="com.plugin.frege.psi.FregePsiClass"
     mixin="com.plugin.frege.psi.mixin.FregePackageClassNameMixin"
+    stubClass="com.plugin.frege.stubs.FregeClassStub"
 }
 
 qName ::= qVarId | qLexOp

--- a/src/main/java/com/plugin/frege/Frege.bnf
+++ b/src/main/java/com/plugin/frege/Frege.bnf
@@ -10,7 +10,7 @@
 
     elementTypeHolderClass="com.plugin.frege.psi.FregeTypes"
     elementTypeClass="com.plugin.frege.psi.FregeElementType"
-    elementTypeFactory("dataNameNative|packageClassName")="com.plugin.frege.psi.FregeElementTypeFactory.factory"
+    elementTypeFactory("dataNameNative|packageClassName|functionName")="com.plugin.frege.psi.FregeElementTypeFactory.factory"
     tokenTypeClass="com.plugin.frege.psi.FregeTokenType"
 }
 
@@ -331,6 +331,7 @@ deriveDcl ::= DERIVE className (constraints DOUBLE_RIGHT_ARROW)? typeRule
 functionName ::= weakVarid {
     mixin="com.plugin.frege.psi.mixin.FregeFunctionNameMixin"
     implements="com.plugin.frege.psi.FregePsiMethod"
+    stubClass="com.plugin.frege.stubs.FregeMethodStub"
 }
 
 /*  Type Annotations */

--- a/src/main/java/com/plugin/frege/psi/FregeElementTypeFactory.java
+++ b/src/main/java/com/plugin/frege/psi/FregeElementTypeFactory.java
@@ -2,6 +2,7 @@ package com.plugin.frege.psi;
 
 import com.intellij.psi.tree.IElementType;
 import com.plugin.frege.stubs.types.FregeDataNativeNameElementType;
+import com.plugin.frege.stubs.types.FregeFunctionNameElementType;
 import com.plugin.frege.stubs.types.FregePackageClassNameElementType;
 
 public class FregeElementTypeFactory {
@@ -11,6 +12,8 @@ public class FregeElementTypeFactory {
                 return new FregeDataNativeNameElementType(name);
             case "PACKAGE_CLASS_NAME":
                 return new FregePackageClassNameElementType(name);
+            case "FUNCTION_NAME":
+                return new FregeFunctionNameElementType(name);
             default:
                 throw new IllegalStateException("Unknown element name: " + name);
         }

--- a/src/main/java/com/plugin/frege/psi/FregeElementTypeFactory.java
+++ b/src/main/java/com/plugin/frege/psi/FregeElementTypeFactory.java
@@ -1,14 +1,18 @@
 package com.plugin.frege.psi;
 
 import com.intellij.psi.tree.IElementType;
-import com.plugin.frege.stubs.types.FregeClassElementType;
+import com.plugin.frege.stubs.types.FregeDataNativeNameElementType;
+import com.plugin.frege.stubs.types.FregePackageClassNameElementType;
 
 public class FregeElementTypeFactory {
     public static IElementType factory(String name) {
-        if (name.equals("DATA_NAME_NATIVE")) {
-            return new FregeClassElementType(name);
-        } else {
-            throw new IllegalStateException("Unknown element name: " + name);
+        switch (name) {
+            case "DATA_NAME_NATIVE":
+                return new FregeDataNativeNameElementType(name);
+            case "PACKAGE_CLASS_NAME":
+                return new FregePackageClassNameElementType(name);
+            default:
+                throw new IllegalStateException("Unknown element name: " + name);
         }
     }
 }

--- a/src/main/java/com/plugin/frege/psi/FregePsiMethod.java
+++ b/src/main/java/com/plugin/frege/psi/FregePsiMethod.java
@@ -2,5 +2,5 @@ package com.plugin.frege.psi;
 
 import com.intellij.psi.PsiMethod;
 
-public interface FregePsiMethod extends PsiMethod {
+public interface FregePsiMethod extends FregeNamedElement, PsiMethod {
 }

--- a/src/main/java/com/plugin/frege/psi/impl/FregePsiClassUtilImpl.java
+++ b/src/main/java/com/plugin/frege/psi/impl/FregePsiClassUtilImpl.java
@@ -15,13 +15,11 @@ import com.plugin.frege.FregeFileType;
 import com.plugin.frege.psi.FregePsiClass;
 import com.plugin.frege.psi.FregePsiClassHolder;
 import com.plugin.frege.stubs.index.FregeClassNameIndex;
+import com.plugin.frege.stubs.index.FregeMethodNameIndex;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class FregePsiClassUtilImpl {
@@ -103,6 +101,17 @@ public class FregePsiClassUtilImpl {
         String qualifier = FregePsiUtilImpl.qualifierFromQualifiedName(qualifiedName);
         if (qualifier.isEmpty()) {
             return List.of();
+        }
+
+        List<PsiMethod> methodsByName = FregeMethodNameIndex.getInstance()
+                .get(name, project, GlobalSearchScope.everythingScope(project)).stream()
+                .filter(method -> {
+                    PsiClass containingClass = method.getContainingClass(); // TODO store this in stub
+                    return containingClass != null && Objects.equals(containingClass.getQualifiedName(), qualifier);
+                }).collect(Collectors.toList());
+
+        if (!methodsByName.isEmpty()) {
+            return methodsByName;
         }
 
         return getClassesByQualifiedName(project, qualifier).

--- a/src/main/java/com/plugin/frege/psi/impl/FregePsiMethodImpl.java
+++ b/src/main/java/com/plugin/frege/psi/impl/FregePsiMethodImpl.java
@@ -8,12 +8,14 @@ import com.intellij.psi.impl.light.LightReferenceListBuilder;
 import com.intellij.psi.impl.light.LightTypeElement;
 import com.intellij.psi.javadoc.PsiDocComment;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.util.MethodSignature;
 import com.intellij.psi.util.MethodSignatureBackedByPsiMethod;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.plugin.frege.FregeLanguage;
 import com.plugin.frege.psi.FregeBinding;
 import com.plugin.frege.psi.FregePsiMethod;
+import com.plugin.frege.stubs.FregeMethodStub;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -22,12 +24,16 @@ import java.util.List;
 import java.util.Objects;
 
 @SuppressWarnings("UnstableApiUsage")
-public abstract class FregePsiMethodImpl extends FregeNamedElementImpl implements FregePsiMethod {
+public abstract class FregePsiMethodImpl extends FregeNamedStubBasedPsiElementBase<FregeMethodStub> implements FregePsiMethod {
     static private PsiType objectType = null;
     private LightTypeElement objectTypeElement = null;
 
     public FregePsiMethodImpl(@NotNull ASTNode node) {
         super(node);
+    }
+
+    public FregePsiMethodImpl(@NotNull FregeMethodStub stub, @NotNull IStubElementType nodeType) {
+        super(stub, nodeType);
     }
 
     @Override
@@ -129,7 +135,11 @@ public abstract class FregePsiMethodImpl extends FregeNamedElementImpl implement
 
     @Override
     public @NotNull String getName() {
-        return Objects.requireNonNull(super.getName()); // only for making it @NotNull
+        FregeMethodStub stub = getGreenStub();
+        if (stub != null) {
+            return Objects.requireNonNull(stub.getName());
+        }
+        return getText();
     }
 
     protected abstract int getParamsNumber();

--- a/src/main/java/com/plugin/frege/psi/mixin/FregeFunctionNameMixin.java
+++ b/src/main/java/com/plugin/frege/psi/mixin/FregeFunctionNameMixin.java
@@ -6,6 +6,7 @@ import com.intellij.psi.*;
 import com.intellij.psi.impl.light.LightModifierList;
 import com.intellij.psi.impl.source.HierarchicalMethodSignatureImpl;
 import com.intellij.psi.impl.source.tree.java.PsiCodeBlockImpl;
+import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.MethodSignatureBackedByPsiMethod;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -15,6 +16,7 @@ import com.plugin.frege.psi.*;
 import com.plugin.frege.psi.impl.FregePsiMethodImpl;
 import com.plugin.frege.psi.impl.FregePsiUtilImpl;
 import com.plugin.frege.resolve.FregeFunctionNameReference;
+import com.plugin.frege.stubs.FregeMethodStub;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,6 +33,11 @@ public class FregeFunctionNameMixin extends FregePsiMethodImpl implements PsiIde
         super(node);
         modifierList = new LightModifierList(getManager(), FregeLanguage.INSTANCE,
                 PsiModifier.STATIC, PsiModifier.FINAL, PsiModifier.PUBLIC); // TODO
+    }
+
+    public FregeFunctionNameMixin(@NotNull FregeMethodStub stub, @NotNull IStubElementType nodeType) {
+        super(stub, nodeType);
+        modifierList = new LightModifierList(getManager(), FregeLanguage.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/plugin/frege/psi/mixin/FregePackageClassNameMixin.java
+++ b/src/main/java/com/plugin/frege/psi/mixin/FregePackageClassNameMixin.java
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiIdentifier;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.stubs.IStubElementType;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
@@ -13,6 +14,7 @@ import com.plugin.frege.psi.*;
 import com.plugin.frege.psi.impl.FregePsiClassImpl;
 import com.plugin.frege.psi.impl.FregePsiUtilImpl;
 import com.plugin.frege.resolve.FregePackageClassNameReference;
+import com.plugin.frege.stubs.FregeClassStub;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -23,6 +25,10 @@ import static com.plugin.frege.psi.FregeTypes.PACKAGE_CLASS_NAME;
 public class FregePackageClassNameMixin extends FregePsiClassImpl implements PsiIdentifier {
     public FregePackageClassNameMixin(@NotNull ASTNode node) {
         super(node);
+    }
+
+    public FregePackageClassNameMixin(@NotNull FregeClassStub stub, @NotNull IStubElementType nodeType) {
+        super(stub, nodeType);
     }
 
     @Override

--- a/src/main/java/com/plugin/frege/stubs/FregeClassStub.java
+++ b/src/main/java/com/plugin/frege/stubs/FregeClassStub.java
@@ -1,7 +1,6 @@
 package com.plugin.frege.stubs;
 
 import com.intellij.psi.stubs.IStubElementType;
-import com.intellij.psi.stubs.NamedStubBase;
 import com.intellij.psi.stubs.StubElement;
 import com.intellij.util.io.StringRef;
 import com.plugin.frege.psi.FregePsiClass;
@@ -9,28 +8,12 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 // TODO keep more data
-public class FregeClassStub extends NamedStubBase<FregePsiClass> {
-    /**
-     * In order to distinct different classes (native data, module, etc)
-     */
-    private final int typeOrder;
-
-    public FregeClassStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable String name, int typeOrder) {
+public class FregeClassStub extends FregeNamedStub<FregePsiClass> {
+    public FregeClassStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable String name) {
         super(parent, elementType, name);
-        this.typeOrder = typeOrder;
     }
 
-    public FregeClassStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable StringRef name, int typeOrder) {
+    public FregeClassStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable StringRef name) {
         super(parent, elementType, name);
-        this.typeOrder = typeOrder;
-    }
-
-    @Override
-    public @Nullable String getName() {
-        return super.getName();
-    }
-
-    public int getTypeOrder() {
-        return typeOrder;
     }
 }

--- a/src/main/java/com/plugin/frege/stubs/FregeMethodStub.java
+++ b/src/main/java/com/plugin/frege/stubs/FregeMethodStub.java
@@ -1,0 +1,19 @@
+package com.plugin.frege.stubs;
+
+import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.stubs.StubElement;
+import com.intellij.util.io.StringRef;
+import com.plugin.frege.psi.FregePsiMethod;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+// TODO keep more data
+public class FregeMethodStub extends FregeNamedStub<FregePsiMethod> {
+    public FregeMethodStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable StringRef name) {
+        super(parent, elementType, name);
+    }
+
+    public FregeMethodStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable String name) {
+        super(parent, elementType, name);
+    }
+}

--- a/src/main/java/com/plugin/frege/stubs/FregeNamedStub.java
+++ b/src/main/java/com/plugin/frege/stubs/FregeNamedStub.java
@@ -1,0 +1,19 @@
+package com.plugin.frege.stubs;
+
+import com.intellij.psi.stubs.IStubElementType;
+import com.intellij.psi.stubs.NamedStubBase;
+import com.intellij.psi.stubs.StubElement;
+import com.intellij.util.io.StringRef;
+import com.plugin.frege.psi.FregeNamedElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class FregeNamedStub<T extends FregeNamedElement> extends NamedStubBase<T> {
+    public FregeNamedStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable StringRef name) {
+        super(parent, elementType, name);
+    }
+
+    public FregeNamedStub(StubElement parent, @NotNull IStubElementType elementType, @Nullable String name) {
+        super(parent, elementType, name);
+    }
+}

--- a/src/main/java/com/plugin/frege/stubs/index/FregeMethodNameIndex.java
+++ b/src/main/java/com/plugin/frege/stubs/index/FregeMethodNameIndex.java
@@ -1,0 +1,23 @@
+package com.plugin.frege.stubs.index;
+
+import com.intellij.psi.stubs.StringStubIndexExtension;
+import com.intellij.psi.stubs.StubIndexKey;
+import com.plugin.frege.psi.FregePsiMethod;
+import org.jetbrains.annotations.NotNull;
+
+public class FregeMethodNameIndex extends StringStubIndexExtension<FregePsiMethod> {
+    private static final StubIndexKey<String, FregePsiMethod> KEY =
+            StubIndexKey.createIndexKey("com.plugin.frege.stubs.index.FregeMethodNameIndex");
+    private static final FregeMethodNameIndex INSTANCE = new FregeMethodNameIndex();
+
+    private FregeMethodNameIndex() { }
+
+    public static FregeMethodNameIndex getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public @NotNull StubIndexKey<String, FregePsiMethod> getKey() {
+        return KEY;
+    }
+}

--- a/src/main/java/com/plugin/frege/stubs/types/FregeClassElementType.java
+++ b/src/main/java/com/plugin/frege/stubs/types/FregeClassElementType.java
@@ -1,17 +1,17 @@
 package com.plugin.frege.stubs.types;
 
-import com.intellij.psi.stubs.*;
+import com.intellij.psi.stubs.StubElement;
+import com.intellij.psi.stubs.StubIndexKey;
+import com.intellij.psi.stubs.StubInputStream;
 import com.intellij.util.io.StringRef;
 import com.plugin.frege.psi.FregePsiClass;
-import com.plugin.frege.psi.impl.FregeDataNameNativeImpl;
 import com.plugin.frege.stubs.FregeClassStub;
 import com.plugin.frege.stubs.index.FregeClassNameIndex;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.Arrays;
 
-public class FregeClassElementType extends FregeNamedStubElementType<FregeClassStub, FregePsiClass> {
+public abstract class FregeClassElementType extends FregeNamedStubElementType<FregeClassStub, FregePsiClass> {
     public FregeClassElementType(@NotNull String debugName) {
         super(debugName);
     }
@@ -22,57 +22,18 @@ public class FregeClassElementType extends FregeNamedStubElementType<FregeClassS
     }
 
     @Override
-    public FregePsiClass createPsi(@NotNull FregeClassStub stub) {
-        return FregeClassType.values()[stub.getTypeOrder()].create(stub, this);
-    }
-
-    @Override
     public @NotNull FregeClassStub createStub(@NotNull FregePsiClass psi, StubElement<?> parentStub) {
-        return new FregeClassStub(parentStub, this, psi.getQualifiedName(), getType(psi));
-    }
-
-    @Override
-    public void serialize(@NotNull FregeClassStub stub, @NotNull StubOutputStream dataStream) throws IOException {
-        dataStream.writeName(stub.getName());
-        dataStream.writeShort(stub.getTypeOrder());
+        return new FregeClassStub(parentStub, this, psi.getQualifiedName());
     }
 
     @Override
     public @NotNull FregeClassStub deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
         StringRef name = dataStream.readName();
-        int type = dataStream.readShort();
-        return new FregeClassStub(parentStub, this, name, type);
+        return new FregeClassStub(parentStub, this, name);
     }
 
     @Override
     public @NotNull String getExternalId() {
         return "frege.CLASS";
-    }
-
-    private int getType(FregePsiClass psiClass) {
-        return FregeClassType.getTypeByClass(psiClass.getClass());
-    }
-
-    private enum FregeClassType {
-        @SuppressWarnings("unused")
-        DATA_NATIVE {
-            public FregePsiClass create(FregeClassStub stub, IStubElementType<?, ?> stubType) {
-                return new FregeDataNameNativeImpl(stub, stubType);
-            }
-            public Class<?> getCorrespondingClass() {
-                return FregeDataNameNativeImpl.class;
-            }
-        }; // TODO add more classes
-
-        protected abstract Class<?> getCorrespondingClass();
-
-        public abstract FregePsiClass create(FregeClassStub stub, IStubElementType<?, ?> stubType);
-
-        public static int getTypeByClass(Class<?> clazz) {
-            return Arrays.stream(FregeClassType.values())
-                    .filter(value -> value.getCorrespondingClass() == clazz)
-                    .findFirst().orElseThrow(() -> new IllegalArgumentException("Such class is not supported."))
-                    .ordinal();
-        }
     }
 }

--- a/src/main/java/com/plugin/frege/stubs/types/FregeDataNativeNameElementType.java
+++ b/src/main/java/com/plugin/frege/stubs/types/FregeDataNativeNameElementType.java
@@ -1,0 +1,22 @@
+package com.plugin.frege.stubs.types;
+
+import com.plugin.frege.psi.FregePsiClass;
+import com.plugin.frege.psi.impl.FregeDataNameNativeImpl;
+import com.plugin.frege.stubs.FregeClassStub;
+import org.jetbrains.annotations.NotNull;
+
+public class FregeDataNativeNameElementType extends FregeClassElementType {
+    public FregeDataNativeNameElementType(@NotNull String debugName) {
+        super(debugName);
+    }
+
+    @Override
+    public FregePsiClass createPsi(@NotNull FregeClassStub stub) {
+        return new FregeDataNameNativeImpl(stub, this);
+    }
+
+    @Override
+    public @NotNull String getExternalId() {
+        return super.getExternalId() + ".DATA_NATIVE";
+    }
+}

--- a/src/main/java/com/plugin/frege/stubs/types/FregeFunctionNameElementType.java
+++ b/src/main/java/com/plugin/frege/stubs/types/FregeFunctionNameElementType.java
@@ -1,0 +1,31 @@
+package com.plugin.frege.stubs.types;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.plugin.frege.psi.FregePsiMethod;
+import com.plugin.frege.psi.impl.FregeFunctionNameImpl;
+import com.plugin.frege.psi.impl.FregePsiUtilImpl;
+import com.plugin.frege.stubs.FregeMethodStub;
+import org.jetbrains.annotations.NotNull;
+
+public class FregeFunctionNameElementType extends FregeMethodElementType {
+    public FregeFunctionNameElementType(@NotNull String debugName) {
+        super(debugName);
+    }
+
+    @Override
+    public FregePsiMethod createPsi(@NotNull FregeMethodStub stub) {
+        return new FregeFunctionNameImpl(stub, this);
+    }
+
+    @Override
+    public boolean shouldCreateStub(ASTNode node) {
+        PsiElement element = node.getPsi();
+        return FregePsiUtilImpl.isInGlobalScope(element);
+    }
+
+    @Override
+    public @NotNull String getExternalId() {
+        return super.getExternalId() + ".FUNCTION_NAME";
+    }
+}

--- a/src/main/java/com/plugin/frege/stubs/types/FregeMethodElementType.java
+++ b/src/main/java/com/plugin/frege/stubs/types/FregeMethodElementType.java
@@ -1,0 +1,39 @@
+package com.plugin.frege.stubs.types;
+
+import com.intellij.psi.stubs.StubElement;
+import com.intellij.psi.stubs.StubIndexKey;
+import com.intellij.psi.stubs.StubInputStream;
+import com.intellij.util.io.StringRef;
+import com.plugin.frege.psi.FregePsiMethod;
+import com.plugin.frege.stubs.FregeMethodStub;
+import com.plugin.frege.stubs.index.FregeMethodNameIndex;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+public abstract class FregeMethodElementType extends FregeNamedStubElementType<FregeMethodStub, FregePsiMethod> {
+    public FregeMethodElementType(@NotNull String debugName) {
+        super(debugName);
+    }
+
+    @Override
+    protected @NotNull StubIndexKey<String, FregePsiMethod> getKey() {
+        return FregeMethodNameIndex.getInstance().getKey();
+    }
+
+    @Override
+    public @NotNull FregeMethodStub createStub(@NotNull FregePsiMethod psi, StubElement<?> parentStub) {
+        return new FregeMethodStub(parentStub, this, psi.getName());
+    }
+
+    @Override
+    public @NotNull FregeMethodStub deserialize(@NotNull StubInputStream dataStream, StubElement parentStub) throws IOException {
+        StringRef name = dataStream.readName();
+        return new FregeMethodStub(parentStub, this, name);
+    }
+
+    @Override
+    public @NotNull String getExternalId() {
+        return "frege.METHOD";
+    }
+}

--- a/src/main/java/com/plugin/frege/stubs/types/FregePackageClassNameElementType.java
+++ b/src/main/java/com/plugin/frege/stubs/types/FregePackageClassNameElementType.java
@@ -1,0 +1,22 @@
+package com.plugin.frege.stubs.types;
+
+import com.plugin.frege.psi.FregePsiClass;
+import com.plugin.frege.psi.impl.FregePackageClassNameImpl;
+import com.plugin.frege.stubs.FregeClassStub;
+import org.jetbrains.annotations.NotNull;
+
+public class FregePackageClassNameElementType extends FregeClassElementType{
+    public FregePackageClassNameElementType(@NotNull String debugName) {
+        super(debugName);
+    }
+
+    @Override
+    public @NotNull String getExternalId() {
+        return super.getExternalId() + ".PACKAGE_CLASS_NAME";
+    }
+
+    @Override
+    public FregePsiClass createPsi(@NotNull FregeClassStub stub) {
+        return new FregePackageClassNameImpl(stub, this);
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,7 @@
         <java.elementFinder implementation="com.plugin.frege.psi.FregePsiElementFinder"/>
         <stubElementTypeHolder class="com.plugin.frege.psi.FregeTypes"/>
         <stubIndex implementation="com.plugin.frege.stubs.index.FregeClassNameIndex"/>
+        <stubIndex implementation="com.plugin.frege.stubs.index.FregeMethodNameIndex"/>
         <colorSettingsPage implementation="com.plugin.frege.highlighter.FregeColorSettingsPage"/>
         <annotator language="Frege" implementationClass="com.plugin.frege.annotator.FregeAnnotator"/>
 


### PR DESCRIPTION
Please, update the stubs version in `FregeFileElementType` manually to see the difference, but don't commit it. I don't want to update this constant in the repository until all stubs are ready.